### PR TITLE
PartyMode API fix

### DIFF
--- a/config-example.js
+++ b/config-example.js
@@ -45,6 +45,13 @@ module.exports = {
         },
         partyList: {
             enabled: true,
+            presence_db: "janusvr_server"
+        },
+        karanStudy: {
+            enabled: false
+        },
+        user: {
+            enabled: true
         },
         perfLog: {
             enabled: true,

--- a/routes/index.js
+++ b/routes/index.js
@@ -165,7 +165,7 @@ if (global.config.apis.partyList.enabled) {
                             }
                         }
                     }
-                    return res.json(rval.data);
+                    return res.json({'success':true, 'data':rval.data});
                 });
             });
         });

--- a/routes/index.js
+++ b/routes/index.js
@@ -42,7 +42,6 @@ function filterStuckUsers(partyData)
         var rows = JSON.parse(JSON.stringify(result));
         for (var i in rows)
         {
-            console.log(rows[i]);
             onlineUsers.push(rows[i].userId);
         }
         var i = partyData.length;


### PR DESCRIPTION
Attempts to remove offline JanusWeb users that are stuck on the party mode list from the API response by comparing the partymode data and online users list. I've tested that this doesn't cause issues, but without access to the official API server I can't be sure it fixes the issue.

Also added some missing config-example options that I needed to add to run my tests.

Note: Needs apis.partyList.presence_db to be defined with the presence server database name